### PR TITLE
Add alpha setting for while runes are still recharging

### DIFF
--- a/ORB_Config.lua
+++ b/ORB_Config.lua
@@ -35,5 +35,6 @@ ORB_Config_Defaults = {
 
 	-- Out of Combat settings
 	["OOC_Alpha"] = 0.7,
+	["OOC_NotAllReadyAlpha"] = 0.7,
 	["SeenTRBTransition"] = false
 };

--- a/ORB_Options.lua
+++ b/ORB_Options.lua
@@ -31,29 +31,40 @@ function ORB_Options:init()
 	-- Main panel
 	--
 	local xoff, yoff = 20, -20;
-	
+
 	local header = panel:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge");
 	header:SetPoint("TOPLEFT", panel, "TOPLEFT", xoff, yoff);
 	header:SetText(panel.name.." v"..GetAddOnMetadata("Onerunebar", "Version") );
 	panel.header = header;
-	
+
+	local function createSlider(name, textFormat, yoffset, getter, setter)
+		local slider = CreateFrame("slider", name, panel, "OptionsSliderTemplate");
+		slider:SetPoint("TOPLEFT", panel, "TOPLEFT", xoff, yoff+yoffset);
+		slider:SetWidth(200);
+		slider:SetHeight(20);
+		slider:SetOrientation("HORIZONTAL");
+		slider:SetMinMaxValues(0, 1.0);
+		slider:SetValue(1);
+		slider:SetValueStep(0.05);
+		_G[slider:GetName().."Low"]:SetText("0.0");
+		_G[slider:GetName().."High"]:SetText("1.0");
+		slider.Text = _G[slider:GetName().."Text"];
+
+		slider:SetScript("OnValueChanged", function(self, value)
+			self.Text:SetText(format(textFormat, value))
+			setter(OneRuneBar, value);
+		end);
+
+		slider:SetValue(getter(OneRuneBar));
+		return slider;
+	end
+
 	-- OOC Alpha
-	local OOCSlider = CreateFrame("slider", "ORB_OOCSlider", panel, "OptionsSliderTemplate");
-	OOCSlider:SetPoint("TOPLEFT", panel, "TOPLEFT", xoff, yoff-50);
-	OOCSlider:SetWidth(200);
-	OOCSlider:SetHeight(20);
-	OOCSlider:SetOrientation("HORIZONTAL");
-	OOCSlider:SetMinMaxValues(0, 1.0);
-	OOCSlider:SetValue(1);
-	OOCSlider:SetValueStep(0.05);
-	_G[OOCSlider:GetName().."Low"]:SetText("0.0");
-	_G[OOCSlider:GetName().."High"]:SetText("1.0");
-	OOCSlider.Text = _G[OOCSlider:GetName().."Text"];
-	OOCSlider:SetScript("OnValueChanged", function(self, value) ORB_Options:SetOOCAlphaValue(self, value); end);
-	OOCSlider:SetValue(OneRuneBar:Config_GetOOCAlpha());
-	OOCSlider.Text:SetText( format("Out of Combat Alpha: %.2f", OOCSlider:GetValue()) );
-	self.OOCSlider = OOCSlider;
-	
+	self.OOCSlider = createSlider("ORB_OOCSlider", "Out of Combat (OOC) alpha: %.2f",
+		-50, OneRuneBar.Config_GetOOCAlpha, OneRuneBar.Config_SetOOCAlpha);
+	self.OOCNotAllReadySlider = createSlider("ORB_OOCNotAllReadySlider", "OOC alpha while still recharging %.2f",
+		-100, OneRuneBar.Config_GetOOCNotAllReadyAlpha, OneRuneBar.Config_SetOOCNotAllReadyAlpha);
+
 	--
 	-- Add panel to blizzards addon config
 	--
@@ -107,13 +118,6 @@ function ORB_Options:Default()
 			m:_OnDefault();
 		end
 	end
-end
-
-function ORB_Options:SetOOCAlphaValue(slider, value)
-	slider.Text:SetText(format("Out of Combat Alpha: %.2f", value) );
-
-	-- Preview update
-	OneRuneBar:Config_SetOOCAlpha(value);
 end
 
 -- add Options to ORB

--- a/ORB_Runes.lua
+++ b/ORB_Runes.lua
@@ -175,6 +175,15 @@ function ORB_Runes:UpdateRuneInfoTable()
 	end
 end
 
+function ORB_Runes:AreAllReady()
+	for runeIndex=1,6 do
+		local start, duration, ready = GetRuneCooldown( runeIndex );
+		if( not ready ) then return false end;
+	end
+	return true;
+end
+
+
 function ORB_sort(t)
 	local itemCount = #t;
 
@@ -207,6 +216,12 @@ end
 function ORB_Runes:UpdateFullBar()
 	self:UpdateRuneInfoTable();
 	self:SortRuneInfos();
+
+	local previousAllReadyState = self.allReadyState;
+	self.allReadyState = self:AreAllReady();
+	if (self.allReadyState ~= previousAllReadyState) then
+		OneRuneBar:UpdateCombatFading();
+	end
 
 	for runeIndex=1, 6 do
 		local oldValue = self.Runes[runeIndex]:GetValue();

--- a/OneRuneBar.lua
+++ b/OneRuneBar.lua
@@ -18,7 +18,9 @@ function OneRuneBar:UpdateCombatFading()
 	local value = self:Config_GetOOCAlpha();
 
 	-- In combat it should be fully visible
-	if( self.inCombat ) then value = 1.0; end
+	if( self.inCombat ) then value = 1.0;
+	-- OOC, but not all runes ready
+	elseif ( not ORB_Runes:AreAllReady() ) then value = self:Config_GetOOCNotAllReadyAlpha(); end
 
 	-- Update alpha value for modules
 	for name, m in pairs(self.modules) do
@@ -161,8 +163,18 @@ function OneRuneBar:Config_GetOOCAlpha()
 	return ORB_Config.OOC_Alpha or ORB_Config_Defaults.OOC_Alpha;
 end
 
+function OneRuneBar:Config_GetOOCNotAllReadyAlpha()
+	return ORB_Config.OOC_NotAllReadyAlpha or ORB_Config_Defaults.OOC_NotAllReadyAlpha;
+end
+
 function OneRuneBar:Config_SetOOCAlpha(val)
 	ORB_Config.OOC_Alpha = val;
+
+	self:UpdateCombatFading();
+end
+
+function OneRuneBar:Config_SetOOCNotAllReadyAlpha(val)
+	ORB_Config.OOC_NotAllReadyAlpha = val;
 
 	self:UpdateCombatFading();
 end


### PR DESCRIPTION
I always wanted an option to have separate alpha settings while OOC for while runes are still recharging and when all are ready.  For me the primary use case is to completely hide it when all runes are ready if I'm OOC. 

I finally got off my ass and made the change today.

Here's what the UI looks like with my changes:
![image](https://user-images.githubusercontent.com/3155381/45258188-a15d0a00-b368-11e8-86b1-e8a3419c7866.png)
